### PR TITLE
fix: include scheduler extra in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ WORKDIR /app
 COPY pyproject.toml uv.lock README.md ./
 
 # Create virtual environment and install dependencies
-# Only install webhook extra (not dev dependencies)
-RUN uv sync --frozen --no-dev --extra webhook --extra cli
+# Install webhook, cli, and scheduler extras (not dev dependencies)
+# Scheduler is included to enable scheduled batch operations out of the box
+RUN uv sync --frozen --no-dev --extra webhook --extra cli --extra scheduler
 
 # Copy source code
 COPY src/ ./src/


### PR DESCRIPTION
## Summary
- Fixes APScheduler import error when running the Docker image with scheduler enabled (the default)
- Adds `--extra scheduler` to the `uv sync` command in Dockerfile

## Problem
The Docker image was built with only `webhook` and `cli` extras, but `docker-compose.yml` sets `FINDARR_SCHEDULER_ENABLED=true` by default. This caused runtime errors:
```
APScheduler not installed. Install with: pip install findarr[scheduler]
```

## Solution
Include the `scheduler` extra in the Docker build so scheduled batch operations work out of the box.

## Test plan
- [ ] Build Docker image locally: `docker build -t findarr-test .`
- [ ] Run container and verify scheduler starts without errors
- [ ] Confirm `/health` endpoint returns healthy status