### PR TITLE
perf: skip CI workflow for release-please commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    # Skip CI for release-please commits - the Release workflow handles validation
+    if: "${{ startsWith(github.event.head_commit.message, 'chore(main): release') == false }}"
     outputs:
       python: ${{ steps.filter.outputs.python }}
       docker: ${{ steps.filter.outputs.docker }}


### PR DESCRIPTION
## Summary
- Skip CI workflow when release-please merges a release commit
- The Release workflow already validates before publishing, making CI redundant on these commits
- Reduces CI minutes and avoids duplicate test runs

## How it works
When a commit message starts with `chore(main): release`, the `changes` job is skipped, which cascades to skip all downstream jobs (lint, typecheck, test, docker-build).

## Test plan
- [x] Merge this PR and verify CI skips on the merge commit
- [x] Create a test release-please PR to verify the Release workflow still runs independently