### PR TITLE
perf: optimize CI to reduce GitHub Actions minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel in-progress runs when a new commit is pushed to the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read
@@ -19,6 +24,7 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Skip CI for release-please commits - the Release workflow handles validation
     if: "${{ startsWith(github.event.head_commit.message, 'chore(main): release') == false }}"
     outputs:
@@ -45,9 +51,11 @@ jobs:
               - 'uv.lock'
               - 'Dockerfile'
 
-  lint:
-    name: Lint
+  # Combined lint and type check job (saves ~1 billed minute vs separate jobs)
+  quality:
+    name: Lint & Type Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: changes
     if: ${{ needs.changes.outputs.python == 'true' }}
     steps:
@@ -63,6 +71,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -73,38 +82,17 @@ jobs:
       - name: Run ruff formatter check
         run: uv run ruff format --check src tests
 
-  typecheck:
-    name: Type Check
-    runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.python == 'true' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: "latest"
-
-      - name: Install dependencies
-        run: uv sync --all-extras --dev
-
       - name: Run mypy
         run: uv run mypy src
 
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: changes
     if: ${{ needs.changes.outputs.python == 'true' }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
@@ -120,6 +108,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -138,13 +127,13 @@ jobs:
   docker-build:
     name: Build Docker Image
     runs-on: ubuntu-latest
-    needs: [changes, lint, typecheck, test]
+    timeout-minutes: 15
+    needs: [changes, quality, test]
     # Run if docker files changed AND all required jobs passed or were skipped
     if: |
       always() &&
       needs.changes.outputs.docker == 'true' &&
-      (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
-      (needs.typecheck.result == 'success' || needs.typecheck.result == 'skipped') &&
+      (needs.quality.result == 'success' || needs.quality.result == 'skipped') &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,6 +35,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "latest"
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --all-extras --dev
@@ -50,6 +52,7 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: test
     permissions:
       contents: read
@@ -106,6 +109,7 @@ jobs:
   create-release:
     name: Update GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: build-and-push
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

Implements optimizations from [Blacksmith's guide on reducing GitHub Actions spend](https://www.blacksmith.sh/blog/how-to-reduce-spend-in-github-actions):

| Optimization | Impact | Description |
|--------------|--------|-------------|
| Concurrency | High | Cancels in-progress runs when new commits pushed |
| Job consolidation | Medium | Merged lint + typecheck into single `quality` job |
| fail-fast | Medium | Stops test matrix early on first failure |
| Timeouts | Safety | Prevents stuck jobs from running for 6 hours |
| uv caching | Medium | Caches dependencies between runs |

## Estimated savings

- **Per rapid-fire push sequence**: Cancels N-1 redundant runs
- **Per failed test run**: Saves ~2 min by stopping remaining matrix jobs
- **Per run with cache hit**: Saves ~15-30s on dependency install
- **Job consolidation**: Saves ~1 billed minute per run

## Test plan
- [x] Push multiple commits rapidly to verify cancel-in-progress works
- [x] Verify all jobs complete successfully on clean run
- [x] Check uv cache is being used (look for "Cache restored" in logs)