### PR TITLE
fix: remove remaining findarr references throughout codebase

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Instructions for findarr
+# Copilot Instructions for filtarr
 
 ## Code Review Focus
 
@@ -38,7 +38,7 @@ uv run mypy src
 
 - **Line length**: 100 characters
 - **Target Python**: 3.11+
-- **Import sorting**: isort via ruff (first-party: `findarr`)
+- **Import sorting**: isort via ruff (first-party: `filtarr`)
 - **Type annotations**: Required everywhere (mypy strict mode)
 
 ## Async Patterns
@@ -68,8 +68,8 @@ async def fetch_releases(self, movie_id: int) -> list[Release]:
 
 ## Error Handling
 
-Use custom exceptions from `findarr.exceptions`:
-- `FindarrError` - base exception
+Use custom exceptions from `filtarr.exceptions`:
+- `FiltarrError` - base exception
 - `APIError` - API communication failures
 - `AuthenticationError` - invalid API key
 - `NotFoundError` - resource not found

--- a/.github/instructions/python-quality.instructions.md
+++ b/.github/instructions/python-quality.instructions.md
@@ -106,7 +106,7 @@ d = movie.model_dump()
 - Always set timeouts
 - Use `raise_for_status()` for error handling
 
-## Project-Specific: findarr
+## Project-Specific: filtarr
 
 - 4K detection should check both quality name AND title
 - API responses must be validated with Pydantic models

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -26,7 +26,7 @@ async def check_4k_available(movie_id: int):
 
 ## Pydantic Models
 
-Located in `src/findarr/models/`. Follow these patterns:
+Located in `src/filtarr/models/`. Follow these patterns:
 
 ```python
 from pydantic import BaseModel, ConfigDict, Field
@@ -44,7 +44,7 @@ class Release(BaseModel):
 Enforced by ruff. Order:
 1. Standard library
 2. Third-party (`httpx`, `pydantic`)
-3. First-party (`findarr`)
+3. First-party (`filtarr`)
 
 ## Docstrings
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -11,7 +11,7 @@ import pytest
 import respx
 from httpx import Response
 
-from findarr.clients.radarr import RadarrClient
+from filtarr.clients.radarr import RadarrClient
 
 
 @pytest.fixture

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,9 +147,9 @@ jobs:
             ```bash
             docker run -d \
               -p 8080:8080 \
-              -e FINDARR_RADARR_URL="http://radarr:7878" \
-              -e FINDARR_RADARR_API_KEY="your-key" \
-              -e FINDARR_SONARR_URL="http://sonarr:8989" \
-              -e FINDARR_SONARR_API_KEY="your-key" \
+              -e FILTARR_RADARR_URL="http://radarr:7878" \
+              -e FILTARR_RADARR_API_KEY="your-key" \
+              -e FILTARR_SONARR_URL="http://sonarr:8989" \
+              -e FILTARR_SONARR_API_KEY="your-key" \
               ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
             ```

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Pre-commit hooks for findarr
+# Pre-commit hooks for filtarr
 # Install: uv run pre-commit install
 # Run manually: uv run pre-commit run --all-files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Project-specific instructions for Claude Code.
 
 ## Project Overview
 
-**findarr** is a Python library for checking 4K availability of media items via Radarr/Sonarr search results. It provides a programmatic API for querying whether movies (via Radarr) and TV shows (via Sonarr) are available in 4K resolution from indexers.
+**filtarr** is a Python library for checking media availability via Radarr/Sonarr search results using configurable search criteria. It provides a programmatic API for querying whether movies (via Radarr) and TV shows (via Sonarr) match specific criteria (e.g., 4K resolution, HDR, Dolby Vision) from indexers.
 
 ## Tech Stack
 
@@ -18,7 +18,7 @@ Project-specific instructions for Claude Code.
 ## Project Structure
 
 ```
-src/findarr/
+src/filtarr/
 ├── __init__.py       # Public API exports
 ├── clients/          # Radarr/Sonarr API clients
 │   ├── radarr.py
@@ -45,7 +45,7 @@ uv run pre-commit install
 uv run pytest
 
 # Run tests with coverage
-uv run pytest --cov=findarr --cov-report=term-missing
+uv run pytest --cov=filtarr --cov-report=term-missing
 
 # Lint
 uv run ruff check src tests

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "package-name": "findarr",
+      "package-name": "filtarr",
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "changelog-path": "CHANGELOG.md",
@@ -16,12 +16,12 @@
       "extra-files": [
         {
           "type": "generic",
-          "path": "src/findarr/__init__.py",
+          "path": "src/filtarr/__init__.py",
           "glob": false
         },
         {
           "type": "generic",
-          "path": "src/findarr/webhook.py",
+          "path": "src/filtarr/webhook.py",
           "glob": false
         }
       ]

--- a/src/filtarr/cli.py
+++ b/src/filtarr/cli.py
@@ -1138,7 +1138,7 @@ def schedule_export(
 
     Examples:
         filtarr schedule export --format cron
-        filtarr schedule export --format cron > /etc/cron.d/findarr
+        filtarr schedule export --format cron > /etc/cron.d/filtarr
         filtarr schedule export --format systemd --output /etc/systemd/system/
     """
     from filtarr.scheduler import export_cron, export_systemd
@@ -1234,7 +1234,7 @@ def serve(
     """Start the webhook server to receive Radarr/Sonarr notifications.
 
     The server listens for webhook events from Radarr and Sonarr when new
-    movies or series are added. When a webhook is received, findarr will
+    movies or series are added. When a webhook is received, filtarr will
     automatically check 4K availability and apply tags based on your config.
 
     The scheduler runs batch operations on configured schedules. Use

--- a/src/filtarr/scheduler/exporter.py
+++ b/src/filtarr/scheduler/exporter.py
@@ -150,7 +150,7 @@ def export_systemd_timer(
 #   sudo systemctl enable --now filtarr-{schedule.name}.timer
 
 [Unit]
-Description=Findarr scheduled batch check: {schedule.name}
+Description=Filtarr scheduled batch check: {schedule.name}
 
 [Timer]
 OnCalendar={on_calendar}
@@ -165,7 +165,7 @@ WantedBy=timers.target
 # Generated: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
 
 [Unit]
-Description=Findarr batch check: {schedule.name}
+Description=Filtarr batch check: {schedule.name}
 After=network-online.target
 Wants=network-online.target
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,1 @@
-"""Test suite for findarr."""
+"""Test suite for filtarr."""


### PR DESCRIPTION
## Summary

Completes the findarr → filtarr rename by fixing remaining references that were missed in PR #23.

## Changes

| Category | Files Changed |
|----------|---------------|
| Documentation | `CLAUDE.md`, `.github/copilot-instructions.md`, GitHub instructions |
| Configuration | `release-please-config.json`, `.pre-commit-config.yaml` |
| CI/CD | `.github/workflows/release.yml` environment variables |
| CLI | Help text, examples, systemd service descriptions |
| Tests | `tests/__init__.py` docstring |

## Files Modified

- `.github/copilot-instructions.md` - Header, import path, exception module name
- `.github/instructions/python-quality.instructions.md` - Project-specific section
- `.github/instructions/python.instructions.md` - Model path, import ordering
- `.github/instructions/tests.instructions.md` - Import statement example
- `.github/workflows/release.yml` - `FINDARR_*` → `FILTARR_*` env vars
- `.pre-commit-config.yaml` - Header comment
- `CLAUDE.md` - Project name, description, paths, coverage command
- `release-please-config.json` - Package name and file paths
- `src/filtarr/cli.py` - Cron example, docstring
- `src/filtarr/scheduler/exporter.py` - Systemd service descriptions
- `tests/__init__.py` - Module docstring

## Test Plan

- [x] All 240 tests pass
- [x] Ruff lint checks pass
- [x] Mypy type checks pass
- [x] Pre-commit hooks pass
- [x] No remaining `findarr` references (case-insensitive grep)