### PR TITLE
chore: update uv.lock and remove codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/dabigc/filtarr/actions/workflows/ci.yml/badge.svg)](https://github.com/dabigc/filtarr/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/filtarr.svg)](https://pypi.org/project/filtarr/)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![codecov](https://codecov.io/gh/dabigc/filtarr/graph/badge.svg)](https://codecov.io/gh/dabigc/filtarr)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://github.com/dabigc/filtarr/pkgs/container/filtarr)

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "filtarr"
-version = "0.1.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary

Minor cleanup that was missed in PR #27:

- Update `uv.lock` to sync dependencies
- Remove codecov badge from README (not configured)

---
Generated with Claude Code using Opus 4.5