### PR TITLE
docs: add env_file directive to docker-compose examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,21 +383,30 @@ docker run -d \
 
 #### Docker Compose
 
+Create a `.env` file with your configuration:
+
+```bash
+# .env
+FILTARR_RADARR_URL=http://radarr:7878
+FILTARR_RADARR_API_KEY=your-radarr-key
+FILTARR_SONARR_URL=http://sonarr:8989
+FILTARR_SONARR_API_KEY=your-sonarr-key
+
+# Optional: customize tags
+FILTARR_TAG_AVAILABLE=4k-available
+FILTARR_TAG_UNAVAILABLE=4k-unavailable
+```
+
+Then use this `docker-compose.yml`:
+
 ```yaml
 services:
   filtarr:
     image: ghcr.io/dabigc/filtarr:latest
     container_name: filtarr
+    env_file: .env  # Required - Docker Compose doesn't auto-read .env
     ports:
       - "8080:8080"
-    environment:
-      - FILTARR_RADARR_URL=http://radarr:7878
-      - FILTARR_RADARR_API_KEY=your-radarr-key
-      - FILTARR_SONARR_URL=http://sonarr:8989
-      - FILTARR_SONARR_API_KEY=your-sonarr-key
-      # Optional: customize tags
-      - FILTARR_TAG_AVAILABLE=4k-available
-      - FILTARR_TAG_UNAVAILABLE=4k-unavailable
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
@@ -414,6 +423,8 @@ services:
     image: linuxserver/sonarr:latest
     # ... your sonarr config
 ```
+
+> **Note:** The `env_file: .env` directive is required. Docker Compose does not automatically load `.env` files for variable substitution in the compose file.
 
 #### Building Locally
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@
 #   2. Create .env file with your API keys (see .env.example)
 #   3. Run: docker compose up -d
 #
+# Note: The env_file directive is required - Docker Compose does not
+# automatically read .env files for variable substitution.
+#
 # For development/building locally, use: docker compose --profile build up -d
 
 services:
@@ -13,6 +16,7 @@ services:
     image: ghcr.io/dabigc/filtarr:latest
     container_name: filtarr
     restart: unless-stopped
+    env_file: .env
     ports:
       - "${FILTARR_PORT:-8080}:8080"
     environment:
@@ -56,6 +60,7 @@ services:
       dockerfile: Dockerfile
     container_name: filtarr-dev
     restart: unless-stopped
+    env_file: .env
     ports:
       - "${FILTARR_DEV_PORT:-8081}:8080"
     environment:


### PR DESCRIPTION
## Summary

Fixes Docker Compose not reading `.env` files by adding the required `env_file` directive.

### Problem

Docker Compose does not automatically load `.env` files for variable substitution in the compose file. Users following the current documentation would get errors like:
```
Radarr API key required
```

### Changes

**docker-compose.yml:**
- Added `env_file: .env` to both `filtarr` and `filtarr-dev` services
- Added explanatory comment about the requirement

**README.md:**
- Updated Docker Compose section with `.env` file example
- Added `env_file: .env` to the compose example
- Added note explaining the requirement

## Test Plan

- [ ] Create `.env` file with API keys
- [ ] Run `docker compose up -d`
- [ ] Verify container starts without "API key required" errors