### PR TITLE
docs: add versioning policy and contributing guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,18 @@ When contributing, maintain these security patterns:
 - 4K detection: Relies on the `quality.name` field from Radarr/Sonarr (e.g., "Bluray-2160p", "WEBDL-4K"). We trust their mature parsing instead of doing our own title matching, which avoids false positives from release group names like "4K4U" or "4K77".
 - API key passed via `X-Api-Key` header
 
+## Versioning Policy
+
+This project follows conservative semantic versioning. See [docs/VERSIONING.md](docs/VERSIONING.md) for the full policy.
+
+**Key points:**
+- Currently at v3.x as baseline (accepts this despite pre-1.0 maturity in spirit)
+- Breaking changes (`feat!:`, `fix!:`) should be **exceptionally rare**
+- Use deprecation warnings before removing any public API
+- Most changes should use `feat:` or `fix:` without the `!` suffix
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for commit message guidelines.
+
 ## Testing Strategy
 
 - Use `respx` for mocking httpx requests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,227 @@
+# Contributing to filtarr
+
+Thank you for your interest in contributing to filtarr! This document provides guidelines and best practices for contributing to the project.
+
+## Development Setup
+
+This project uses `uv` for dependency management. To get started:
+
+```bash
+# Clone the repository
+git clone https://github.com/dabigc/filtarr.git
+cd filtarr
+
+# Install with dev dependencies
+uv sync --dev
+
+# Install pre-commit hooks (required)
+uv run pre-commit install
+```
+
+The pre-commit hooks will automatically run linting, type checking, and tests before each commit to ensure code quality.
+
+## Development Workflow
+
+### Running Tests
+
+Always run tests before submitting a pull request:
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run with coverage report
+uv run pytest --cov=filtarr --cov-report=term-missing
+
+# Run integration tests
+uv run pytest -m integration
+```
+
+### Code Quality Checks
+
+The project enforces strict code quality standards:
+
+```bash
+# Lint and format
+uv run ruff check src tests
+uv run ruff format src tests
+
+# Type checking (strict mode)
+uv run mypy src
+
+# Run all pre-commit hooks manually
+uv run pre-commit run --all-files
+```
+
+**IMPORTANT**: All checks must pass before committing. The pre-commit hooks will enforce this automatically.
+
+### Docker Testing
+
+If you modify Docker-related files or core functionality:
+
+```bash
+# Run Docker runtime tests
+./scripts/test-docker.sh
+
+# Verbose output
+./scripts/test-docker.sh --verbose
+```
+
+Docker tests run automatically via pre-commit hooks when relevant files change.
+
+## Commit Message Conventions
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) format for all commit messages. This ensures clear, consistent version history and enables automated changelog generation.
+
+### Basic Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Commit Types
+
+Use these prefixes for your commits:
+
+- **feat**: New feature or enhancement
+- **fix**: Bug fix
+- **chore**: Maintenance tasks (dependencies, build config)
+- **docs**: Documentation changes
+- **test**: Adding or updating tests
+- **refactor**: Code restructuring without functional changes
+- **perf**: Performance improvements
+- **ci**: CI/CD pipeline changes
+- **style**: Code style/formatting changes (whitespace, etc.)
+
+### Examples
+
+```bash
+# Good commit messages
+feat(cli): add batch processing command for series
+fix(checker): prevent 4K false positives from release group names
+chore(deps): update httpx to 0.27.0
+docs(readme): add webhook server usage examples
+test(radarr): add coverage for error handling paths
+
+# Feature with scope
+feat(webhook): add support for Sonarr EpisodeDownload events
+
+# Bug fix with detailed explanation
+fix(state): handle concurrent state updates correctly
+
+Previously, multiple simultaneous updates could cause race conditions.
+Now using file locking to ensure atomicity.
+
+Fixes #123
+```
+
+### Breaking Changes
+
+**Breaking changes should be used VERY sparingly.** They require:
+
+1. **Deprecation warning** in a prior release
+2. **Clear migration path** documented in the commit body
+3. **Strong justification** for why the breaking change is necessary
+
+Use the `!` suffix to indicate breaking changes:
+
+```bash
+# Breaking change format
+feat!(<scope>): breaking change description
+
+BREAKING CHANGE: Detailed explanation of what broke and why.
+
+Migration path:
+- Old API: checker.check_movie(movie_id)
+- New API: checker.check_movie(movie_id, criteria=SearchCriteria.UHD_4K)
+
+Rationale: The new API provides explicit control over search criteria,
+improving clarity and reducing ambiguity in availability checks.
+```
+
+**Before introducing a breaking change:**
+
+1. Open an issue to discuss the change with maintainers
+2. Ensure the benefit outweighs the migration cost
+3. Add deprecation warnings in the current version
+4. Update documentation with migration guides
+5. Use semantic versioning (breaking changes trigger major version bumps)
+
+### Scope Guidelines
+
+Use scopes to indicate which part of the codebase is affected:
+
+- `cli` - Command-line interface
+- `webhook` - Webhook server
+- `scheduler` - Scheduling system
+- `checker` - ReleaseChecker logic
+- `tagger` - ReleaseTagger logic
+- `config` - Configuration system
+- `state` - State management
+- `radarr` - Radarr client
+- `sonarr` - Sonarr client
+- `models` - Data models
+- `deps` - Dependencies
+- `docker` - Docker configuration
+
+Scope is optional but recommended for clarity.
+
+### Commit Message Best Practices
+
+1. **Use imperative mood**: "add feature" not "added feature"
+2. **Keep the summary line under 72 characters**
+3. **Capitalize the summary line**
+4. **No period at the end of the summary**
+5. **Separate summary from body with blank line**
+6. **Wrap body at 72 characters**
+7. **Use body to explain what and why, not how**
+
+## Pull Request Process
+
+1. **Fork the repository** and create a feature branch
+2. **Make your changes** following the code quality guidelines
+3. **Add tests** for new functionality
+4. **Update documentation** if needed
+5. **Ensure all checks pass** (tests, linting, type checking)
+6. **Write clear commit messages** using Conventional Commits format
+7. **Submit a pull request** with a descriptive title and summary
+
+### Pull Request Title
+
+Use the same format as commit messages:
+
+```
+feat(cli): add support for custom output formats
+fix(radarr): handle empty release arrays correctly
+```
+
+### Pull Request Description
+
+Include:
+
+- **Summary** of changes
+- **Motivation** for the change
+- **Testing performed**
+- **Related issues** (if any)
+- **Breaking changes** (if any, with migration guide)
+
+## Code Style Guidelines
+
+- Follow **PEP 8** conventions
+- Use **type hints** for all function signatures
+- Prefer **descriptive names** over abbreviations
+- Keep **functions focused** on a single responsibility
+- Write **docstrings** for public APIs (Google style)
+- Use **async/await** for I/O operations
+
+## Questions or Issues?
+
+- Check existing [issues](https://github.com/dabigc/filtarr/issues)
+- Open a new issue for bugs or feature requests
+- Join discussions in pull requests
+
+Thank you for contributing to filtarr!

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,160 @@
+# Versioning Policy
+
+## Version Philosophy
+
+Filtarr follows **Semantic Versioning 2.0.0** (`MAJOR.MINOR.PATCH`) with a conservative approach to breaking changes.
+
+**Current Status**: Despite being at v3.x, filtarr is a mature pre-1.0 project in spirit. We accept v3.x as our baseline and commit to stability going forward. Users should feel confident that upgrades within the v3.x series will not break their integrations.
+
+**Guiding Principle**: *Stability over rapid iteration.* Breaking changes should be exceptionally rare and well-justified.
+
+## Version Bump Rules
+
+Version bumps are driven by [Conventional Commits](https://www.conventionalcommits.org/) and managed automatically by release-please:
+
+| Commit Type | Version Bump | Example | Use Case |
+|-------------|-------------|---------|----------|
+| `fix:` | **PATCH** | 3.0.0 → 3.0.1 | Bug fixes, documentation, internal refactoring |
+| `feat:` | **MINOR** | 3.0.0 → 3.1.0 | New features, backward-compatible enhancements |
+| `feat!:` or `fix!:` | **MAJOR** | 3.0.0 → 4.0.0 | Breaking changes (**USE SPARINGLY**) |
+
+**Note**: The `!` suffix indicates a breaking change. It should be rare. See the Breaking Changes Policy below.
+
+## Breaking Changes Policy
+
+**Definition**: A breaking change is any modification that could cause existing user code to fail:
+- Removing public API methods, classes, or functions
+- Changing function signatures (adding required parameters, removing parameters)
+- Changing return types in incompatible ways
+- Renaming public modules or classes
+
+**Policy**:
+1. **Avoid breaking changes unless absolutely necessary**
+   - Justify with a clear use case in the PR description
+   - Require maintainer approval before merging
+   - Document the impact and migration path
+
+2. **Use deprecation periods** (see Deprecation Strategy below)
+   - Preferred over immediate removal
+   - Gives users time to migrate
+
+3. **Major version bumps should be infrequent**
+   - Target: no more than 1-2 per year
+   - Bundle multiple breaking changes when possible
+
+## Commit Message Guidelines
+
+Use conventional commits for all changes:
+
+### Standard Commits (Most Common)
+
+```
+fix: prevent 4K false positives from release group names
+feat: add support for Dolby Atmos audio criteria
+docs: update CLI usage examples
+chore: bump httpx dependency to 0.27.0
+test: add coverage for SonarrClient.search_releases
+refactor: extract common retry logic to BaseClient
+```
+
+### Breaking Change Commits (RARE)
+
+Only use `!` when making **genuine breaking changes**:
+
+```
+feat!: require Python 3.11+ (drops 3.9/3.10 support)
+
+BREAKING CHANGE: Minimum Python version is now 3.11.
+Users on Python 3.9 or 3.10 must upgrade.
+```
+
+```
+fix!: remove deprecated ReleaseChecker.check_sync method
+
+BREAKING CHANGE: The synchronous check_sync() method has been
+removed after a 6-month deprecation period. Use the async check()
+method instead.
+```
+
+**When in doubt, do NOT use `!`**. Most changes can be made backward-compatible with careful design.
+
+## Deprecation Strategy
+
+Before removing any public API, follow this process:
+
+### 1. Mark as Deprecated (Minor Version Bump)
+
+Add deprecation warnings using Python's `warnings` module:
+
+```python
+import warnings
+
+def old_function():
+    warnings.warn(
+        "old_function() is deprecated and will be removed in v4.0. "
+        "Use new_function() instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+    return new_function()
+```
+
+### 2. Document the Deprecation
+
+- Add a `.. deprecated::` directive in docstrings
+- Update `CHANGELOG.md` with migration instructions
+- Announce in release notes
+
+### 3. Wait at Least One Minor Version
+
+Give users time to migrate:
+- **Minimum**: 1 minor version (e.g., deprecated in 3.5.0, removed in 3.6.0)
+- **Recommended**: 2-3 minor versions or 3-6 months
+- **For critical APIs**: Longer deprecation periods (6+ months)
+
+### 4. Remove in Next Major Version
+
+When the deprecation period ends, remove the deprecated code in the next major version bump.
+
+## Examples
+
+### Good: Backward-Compatible Feature
+
+```
+feat: add --timeout flag to CLI commands
+
+Adds optional --timeout parameter for HTTP requests.
+Defaults to 30 seconds (existing behavior).
+```
+
+**Result**: 3.5.0 → 3.6.0 (minor bump, no breaking change)
+
+### Bad: Unnecessary Breaking Change
+
+```
+feat!: rename --criteria to --filter
+
+BREAKING CHANGE: The --criteria flag is now --filter.
+```
+
+**Problem**: This breaks user scripts for cosmetic reasons. Instead, support both flags and deprecate the old one.
+
+### Better Alternative
+
+```
+feat: add --filter alias for --criteria flag
+
+The --filter flag is now the preferred name, but --criteria
+continues to work for backward compatibility.
+```
+
+**Result**: 3.5.0 → 3.6.0 (minor bump, fully compatible)
+
+## Summary
+
+- **Be conservative**: Avoid breaking changes whenever possible
+- **Use deprecation**: Give users time to migrate before removing features
+- **Communicate clearly**: Document all changes in CHANGELOG.md
+- **Trust the tooling**: release-please automates version bumps based on commit messages
+
+When in doubt, choose backward compatibility over breaking changes.


### PR DESCRIPTION
## Summary

Establishes a conservative versioning policy for filtarr, formally accepting v3.x as the baseline while committing to stability going forward. This addresses the concern that the project reached v3.0.0 prematurely despite being pre-1.0 in maturity.

**Impact**: 3 files changed (+399 additions)
**Risk Level**: 🟢 Low (documentation only)
**Review Time**: ~5 minutes

## What Changed

### 📝 Documentation Changes

- **New**: `docs/VERSIONING.md` - Comprehensive versioning policy document
- **New**: `CONTRIBUTING.md` - Full contributor guidelines
- **Modified**: `CLAUDE.md` - Added versioning policy summary section

## Why These Changes

After researching release-please configuration options, we discovered:
1. The `bump-minor-pre-major` option only works for versions < 1.0.0
2. PyPI versions are immutable and cannot be rolled back
3. The pragmatic solution is to accept v3.x and commit to conservative versioning

## Key Policy Points

| Commit Type | Version Bump | Usage |
|-------------|--------------|-------|
| `fix:` | PATCH (3.0.0 → 3.0.1) | Bug fixes, docs, refactoring |
| `feat:` | MINOR (3.0.0 → 3.1.0) | New features, enhancements |
| `feat!:` / `fix!:` | MAJOR (3.0.0 → 4.0.0) | **USE SPARINGLY** |

## Review Checklist

### Documentation
- [x] Documentation is clear and accurate
- [x] Examples are provided where helpful
- [x] README references added in CLAUDE.md
- [x] Follows project markdown conventions

### Policy Coverage
- [x] Version bump rules documented
- [x] Breaking change policy defined
- [x] Deprecation strategy with code examples
- [x] Commit message guidelines
- [x] Practical good/bad examples included

## Files Changed

```
 CLAUDE.md          |  12 +++
 CONTRIBUTING.md    | 227 +++++++++++++++++++++++++++++++++++++++++++++
 docs/VERSIONING.md | 160 +++++++++++++++++++++++++++++++
 3 files changed, 399 insertions(+)
```

## Test Plan

- [x] No code changes - documentation only
- [x] Markdown renders correctly
- [x] Links between documents work
- [x] Pre-commit hooks pass