### PR TITLE
ci: add PR preview Docker build workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -85,3 +85,39 @@ jobs:
 
             Built from ${{ github.sha }}
           comment-tag: pr-preview
+
+  cleanup:
+    name: Cleanup Preview Image
+    if: >-
+      github.event.action == 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete preview image from GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TAG: pr-${{ github.event.pull_request.number }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
+        run: |
+          VERSION_ID=$(gh api --paginate \
+            "/users/$OWNER/packages/container/$PACKAGE/versions" \
+            --jq ".[] | select(.metadata.container.tags[] == \"$PR_TAG\") | .id")
+
+          if [ -n "$VERSION_ID" ]; then
+            gh api --method DELETE \
+              "/users/$OWNER/packages/container/$PACKAGE/versions/$VERSION_ID"
+            echo "Deleted preview image $PR_TAG (version $VERSION_ID)"
+          else
+            echo "No preview image found for $PR_TAG — nothing to clean up"
+          fi
+
+      - name: Comment on PR
+        if: success()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Preview image `pr-${{ github.event.pull_request.number }}` has been cleaned up.
+          comment-tag: pr-preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,87 @@
+name: PR Preview Build
+
+on:
+  pull_request:
+    types: [labeled, synchronize, closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to build a preview image for"
+        required: true
+        type: number
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build Preview Image
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'deploy-preview') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'deploy-preview')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push preview image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ steps.pr.outputs.number }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}/pull/${{ steps.pr.outputs.number }}
+            org.opencontainers.image.description=PR preview build for #${{ steps.pr.outputs.number }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          body: |
+            ### Preview image built and pushed
+
+            ```
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ steps.pr.outputs.number }}
+            ```
+
+            Built from ${{ github.sha }}
+          comment-tag: pr-preview

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -77,7 +77,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ steps.pr.outputs.number }}
           body: |
@@ -125,7 +125,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.delete.outputs.deleted == 'true'
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -36,11 +36,15 @@ jobs:
     steps:
       - name: Resolve PR number
         id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "number=$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
           else
-            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout repository
@@ -83,7 +87,7 @@ jobs:
             docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ steps.pr.outputs.number }}
             ```
 
-            Built from ${{ github.sha }}
+            Built from ${{ github.event.pull_request.head.sha || github.sha }}
           comment-tag: pr-preview
 
   cleanup:
@@ -93,8 +97,12 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'deploy-preview')
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: pr-preview-cleanup-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
     steps:
       - name: Delete preview image from GHCR
+        id: delete
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TAG: pr-${{ github.event.pull_request.number }}
@@ -109,12 +117,14 @@ jobs:
             gh api --method DELETE \
               "/users/$OWNER/packages/container/$PACKAGE/versions/$VERSION_ID"
             echo "Deleted preview image $PR_TAG (version $VERSION_ID)"
+            echo "deleted=true" >> "$GITHUB_OUTPUT"
           else
             echo "No preview image found for $PR_TAG — nothing to clean up"
+            echo "deleted=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Comment on PR
-        if: success()
+        if: steps.delete.outputs.deleted == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/docs/superpowers/plans/2026-05-15-pr-preview-docker-builds.md
+++ b/docs/superpowers/plans/2026-05-15-pr-preview-docker-builds.md
@@ -1,0 +1,242 @@
+# PR Preview Docker Image Builds — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in GitHub Actions workflow that builds Docker images from PRs with `pr-{number}` tags and cleans up on close.
+
+**Architecture:** Single workflow file (`.github/workflows/pr-preview.yml`) with two jobs: `build` (triggered by label or dispatch) and `cleanup` (triggered by PR close). Uses the same Docker toolchain as `release.yml` but amd64-only.
+
+**Tech Stack:** GitHub Actions, Docker Buildx, GHCR, GitHub Packages REST API, `peter-evans/create-or-update-comment` for sticky PR comments.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-pr-preview-docker-builds-design.md`
+
+---
+
+### Task 1: Create workflow file with build job
+
+**Files:**
+- Create: `.github/workflows/pr-preview.yml`
+
+This task creates the complete workflow file with triggers, the build job, and a PR comment. The cleanup job is added in Task 2.
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/pr-preview.yml` with the following content:
+
+```yaml
+name: PR Preview Build
+
+on:
+  pull_request:
+    types: [labeled, synchronize, closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to build a preview image for"
+        required: true
+        type: number
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build Preview Image
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'deploy-preview') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'deploy-preview')) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || format('refs/pull/{0}/head', inputs.pr_number) }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push preview image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ steps.pr.outputs.number }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}/pull/${{ steps.pr.outputs.number }}
+            org.opencontainers.image.description=PR preview build for #${{ steps.pr.outputs.number }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Comment on PR
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          body: |
+            ### Preview image built and pushed
+
+            ```
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:pr-${{ steps.pr.outputs.number }}
+            ```
+
+            Built from ${{ github.sha }}
+          comment-tag: pr-preview
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-preview.yml'))" && echo "YAML OK"`
+
+Expected: `YAML OK`
+
+If `actionlint` is available, also run:
+```bash
+actionlint .github/workflows/pr-preview.yml
+```
+
+- [ ] **Step 3: Commit the build job**
+
+```bash
+git add .github/workflows/pr-preview.yml
+git commit -m "ci: add PR preview Docker build workflow"
+```
+
+---
+
+### Task 2: Add cleanup job
+
+**Files:**
+- Modify: `.github/workflows/pr-preview.yml`
+
+Add the `cleanup` job that deletes the preview image when the PR is closed (merged or abandoned). Uses the GitHub Packages REST API to find and delete the tagged version.
+
+- [ ] **Step 1: Add the cleanup job to pr-preview.yml**
+
+Append the following job after the `build` job in `.github/workflows/pr-preview.yml`:
+
+```yaml
+  cleanup:
+    name: Cleanup Preview Image
+    if: >-
+      github.event.action == 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete preview image from GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TAG: pr-${{ github.event.pull_request.number }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: ${{ github.event.repository.name }}
+        run: |
+          VERSION_ID=$(gh api --paginate \
+            "/users/$OWNER/packages/container/$PACKAGE/versions" \
+            --jq ".[] | select(.metadata.container.tags[] == \"$PR_TAG\") | .id")
+
+          if [ -n "$VERSION_ID" ]; then
+            gh api --method DELETE \
+              "/users/$OWNER/packages/container/$PACKAGE/versions/$VERSION_ID"
+            echo "Deleted preview image $PR_TAG (version $VERSION_ID)"
+          else
+            echo "No preview image found for $PR_TAG — nothing to clean up"
+          fi
+
+      - name: Comment on PR
+        if: success()
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Preview image `pr-${{ github.event.pull_request.number }}` has been cleaned up.
+          comment-tag: pr-preview
+```
+
+- [ ] **Step 2: Validate the complete workflow file**
+
+Run: `python -c "import yaml; yaml.safe_load(open('.github/workflows/pr-preview.yml'))" && echo "YAML OK"`
+
+Expected: `YAML OK`
+
+Also verify the complete file has exactly two jobs (`build` and `cleanup`) and the expected triggers:
+```bash
+python -c "
+import yaml
+with open('.github/workflows/pr-preview.yml') as f:
+    wf = yaml.safe_load(f)
+assert set(wf['jobs'].keys()) == {'build', 'cleanup'}, f'Expected build+cleanup jobs, got {set(wf[\"jobs\"].keys())}'
+assert 'pull_request' in wf['on'], 'Missing pull_request trigger'
+assert 'workflow_dispatch' in wf['on'], 'Missing workflow_dispatch trigger'
+assert set(wf['on']['pull_request']['types']) == {'labeled', 'synchronize', 'closed'}, 'Wrong PR event types'
+print('All checks passed')
+"
+```
+
+Expected: `All checks passed`
+
+- [ ] **Step 3: Commit the cleanup job**
+
+```bash
+git add .github/workflows/pr-preview.yml
+git commit -m "ci: add cleanup job for PR preview images"
+```
+
+- [ ] **Step 4: Verify pre-commit hooks pass**
+
+Run the project's pre-commit checks to make sure nothing is broken:
+
+```bash
+uv run ruff check src tests
+uv run mypy src
+uv run pytest --tb=short -q
+```
+
+Expected: All pass (this change is YAML-only, no Python changes).
+
+---
+
+## Testing Notes
+
+This is a GitHub Actions workflow — it can only be fully tested by pushing to a branch and triggering the workflow on GitHub. To test end-to-end:
+
+1. Push this branch and create a PR against `main`
+2. Add the `deploy-preview` label to the PR
+3. Verify the build runs and pushes `ghcr.io/dabigc/filtarr:pr-{number}`
+4. Verify the sticky comment appears on the PR
+5. Push another commit — verify the build re-runs and the comment updates
+6. Close the PR — verify the cleanup job runs and the image is deleted
+7. Test `workflow_dispatch` — go to Actions, select the workflow, enter a PR number, verify it builds
+
+## Rollback
+
+Delete the workflow file and force-push, or simply merge without the file. No other files are modified, so rollback is trivial.

--- a/docs/superpowers/specs/2026-05-15-pr-preview-docker-builds-design.md
+++ b/docs/superpowers/specs/2026-05-15-pr-preview-docker-builds-design.md
@@ -1,0 +1,140 @@
+# PR Preview Docker Image Builds
+
+## Summary
+
+Add an opt-in GitHub Actions workflow that builds Docker images from pull requests and pushes them to GHCR with PR-specific tags, enabling real-world integration testing before merging.
+
+## Motivation
+
+Currently, Docker images are only published on tagged releases. To test a PR in a production-like environment, you'd need to manually build the image locally and transfer it. This workflow automates that — label a PR, get a pullable image.
+
+## Design
+
+### Workflow File
+
+New file: `.github/workflows/pr-preview.yml`
+
+Separate from `ci.yml` (quality gates) and `release.yml` (production images). Owns the entire PR preview lifecycle: build, push, and cleanup.
+
+### Triggers
+
+| Trigger | Event | Purpose |
+|---------|-------|---------|
+| `pull_request: [labeled]` | Label added to PR | Build when `deploy-preview` label is applied |
+| `pull_request: [synchronize]` | Push to labeled PR | Rebuild on new commits if label is present |
+| `pull_request: [closed]` | PR merged or closed | Clean up the preview image |
+| `workflow_dispatch` | Manual from Actions UI | One-off build by entering a PR number |
+
+### Jobs
+
+#### `build` — Build and Push Preview Image
+
+**Runs when** (any of):
+- `labeled` event AND the label is `deploy-preview`
+- `synchronize` event AND PR currently has `deploy-preview` label
+- `workflow_dispatch` event
+
+**Steps:**
+1. Checkout code — PR events use `github.event.pull_request.head.sha`; dispatch uses `refs/pull/{input.pr_number}/head`
+2. Set up Docker Buildx (no QEMU — amd64 only)
+3. Login to GHCR with `GITHUB_TOKEN`
+4. Resolve PR number from event context or dispatch input
+5. Build and push: `ghcr.io/dabigc/filtarr:pr-{number}` — single platform `linux/amd64`
+6. Comment on PR with the pull command
+
+**Image tag:** `pr-{number}` (e.g., `pr-123`). Overwrites on each push — always points to the latest build for that PR.
+
+#### `cleanup` — Delete Preview Image on PR Close
+
+**Runs when:** `closed` event AND PR has `deploy-preview` label
+
+**Steps:**
+1. Find the package version tagged `pr-{number}` via GitHub REST API (`GET /users/{owner}/packages/container/{name}/versions`)
+2. Delete the version (`DELETE /users/{owner}/packages/container/{name}/versions/{id}`)
+3. Comment on PR confirming image was cleaned up
+
+### Concurrency
+
+```yaml
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+```
+
+Prevents parallel builds for the same PR when commits are pushed in rapid succession.
+
+### Permissions
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  pull-requests: write
+```
+
+- `contents: read` — checkout code
+- `packages: write` — push/delete container images
+- `pull-requests: write` — post comments on the PR
+
+### Security Model
+
+- **No fork PR risk:** This repo does not accept fork PRs. The `pull_request` event (not `pull_request_target`) is safe and has access to `GITHUB_TOKEN` with the permissions above.
+- **Label gating:** Only users with **write** access to the repo can add labels, providing natural access control.
+- **workflow_dispatch gating:** Only users with **write** access can trigger manual workflows.
+- **No additional secrets:** Only `GITHUB_TOKEN` is used — no external registry credentials needed.
+- **If fork PRs are ever accepted in the future:** This workflow should be revisited. The `pull_request` event from forks has limited `GITHUB_TOKEN` permissions and cannot push to GHCR. A `workflow_run` or `pull_request_target` pattern would be needed.
+
+### Tag Hygiene
+
+- PR images use `pr-{number}` prefix — clearly distinct from semver tags (`3.0.1`, `3.0`, `3`, `latest`)
+- No `latest` or version tags are applied to preview images
+- OCI labels include source metadata pointing to the PR
+- Automatic cleanup on PR close prevents tag accumulation
+
+### PR Comments
+
+The workflow posts comments to the PR at two points:
+
+**On successful build:**
+> Preview image built and pushed.
+> ```
+> docker pull ghcr.io/dabigc/filtarr:pr-123
+> ```
+
+**On cleanup (PR close):**
+> Preview image `pr-123` has been cleaned up.
+
+### Build Configuration
+
+- **Platform:** `linux/amd64` only (no arm64 — not needed for test environment)
+- **Cache:** GitHub Actions cache (`type=gha`) for Docker layer caching
+- **Timeout:** 15 minutes
+- **Base image:** Same Dockerfile as production (multi-stage, `python:3.14-alpine`)
+
+### Usage
+
+```bash
+# Option 1: Add label to PR
+# Go to PR → Labels → add "deploy-preview"
+# Image builds automatically on each push
+
+# Option 2: Manual trigger
+# Go to Actions → "PR Preview Build" → Run workflow → enter PR number
+
+# Pull the image on your server
+docker pull ghcr.io/dabigc/filtarr:pr-123
+
+# Run it
+docker run -d \
+  -p 8080:8080 \
+  -e FILTARR_RADARR_URL="http://radarr:7878" \
+  -e FILTARR_RADARR_API_KEY="your-key" \
+  ghcr.io/dabigc/filtarr:pr-123
+```
+
+## Out of Scope
+
+- Multi-arch builds (arm64) — not needed for the test environment
+- Build gating on CI status — preview builds are independent of quality checks
+- Deployment automation — the user manually pulls and runs the image
+- Image signing or attestation — not needed for preview images


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pr-preview.yml` — opt-in workflow that builds Docker images from PRs and pushes to GHCR with `pr-{number}` tags
- **Build trigger:** Add `deploy-preview` label to a PR (auto-builds on each push), or manual `workflow_dispatch` with a PR number
- **Cleanup:** Automatically deletes the preview image from GHCR when the PR is closed/merged
- **Security:** Expression interpolation via `env:` (no script injection), minimal permissions, label-gated access (write access required)

## How to use

```bash
# Option 1: Add "deploy-preview" label to any PR — image builds on each push
# Option 2: Actions → "PR Preview Build" → Run workflow → enter PR number

# Pull the image
docker pull ghcr.io/dabigc/filtarr:pr-123
```

## Design decisions

- **amd64 only** — skip arm64 to save CI time (not needed for test environment)
- **Separate workflow** — keeps `ci.yml` focused on quality gates, `release.yml` on production images
- **Sticky PR comment** — updates in place instead of creating duplicates on each push
- **Job-level concurrency on cleanup** — prevents cleanup from being cancelled by rapid PR events

## Test plan

- [ ] Push branch, create PR, add `deploy-preview` label — verify build runs and image is pushed
- [ ] Push another commit — verify build re-runs and comment updates
- [ ] Test `workflow_dispatch` with PR number — verify one-off build works
- [ ] Close PR — verify cleanup job deletes the image and updates comment
- [ ] Verify `docker pull ghcr.io/dabigc/filtarr:pr-{number}` works from external server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>